### PR TITLE
feat(image): build additional image with prelive-ionos DNS

### DIFF
--- a/.env.prelive-ionos
+++ b/.env.prelive-ionos
@@ -1,0 +1,8 @@
+# settings for parallel prelive environment in IONOS. Can be removed once prelive is migrated.
+NODE_ENV=production
+VITE_BASE_PATH=/
+VITE_API_SERVER=https://api.prelive-ionos.forschen-fuer-gesundheit.de/api/v1
+VITE_KEYCLOAK_BASE_URL=https://keycloak-ionos.prelive.forschen-fuer-gesundheit.de
+VITE_KEYCLOAK_REALM=fdpg
+VITE_KEYCLOAK_CLIENT_ID=fdpg-webapp
+VITE_FEASIBILITY_HOST=https://feasibility.forschen-fuer-gesundheit.de

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -61,6 +61,14 @@ jobs:
       nodeEnvironment: "prelive"
     secrets: inherit
 
+  build_prelive_ionos:
+    uses: ./.github/workflows/build-and-publish.template.yaml
+    if: ${{ github.ref == 'refs/heads/main' }}  # isMain == true
+    needs: verify
+    with:
+      nodeEnvironment: "prelive-ionos"
+    secrets: inherit
+
 
   build_main:
     uses: ./.github/workflows/build-and-publish.template.yaml


### PR DESCRIPTION
since we want to run a parallel prelive environment in IONOS until prelive is fully migrated, we need a webapp container image with prelive-IONOS URLs since they get hardcoded into the images.