### PR TITLE
fix: configure nginx to serve index.html as fallback for unknown files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginxinc/nginx-unprivileged
 
+COPY --chown=nginx nginx_default.conf /etc/nginx/conf.d/default.conf
 COPY ./dist /usr/share/nginx/html

--- a/nginx_default.conf
+++ b/nginx_default.conf
@@ -1,0 +1,14 @@
+# Copied and adjusted from Docker base image nginxinc/nginx-unprivileged
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index;
+        # Fall back to index.html for URLs where a corresponding JS/HTML/asset file does not exist. This is required
+        # so that nginx responds with the index.html to requests to the Oauth2 authorization code flow redirect URL /auth/...
+        # Browsers will then load the index.html and the JS app will handle the URL and finish the Oauth2 flow.
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
This is required so that nginx responds with the index.html to requests to the Oauth2 authorization code flow redirect URL /auth/...

Browsers will then load the index.html and the JS app will handle the URL and finish the Oauth2 flow.